### PR TITLE
PFX Export Mail Function and Smaller Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ In case you would like to see which mail, addresses are not validated or cancel 
 
 ![](media/144be2473ad0f13741ce24f22d2b927f.png)
 
+### PFX Export User Flow
+
+For non-MDM managed devices, it is possible to utilize the Send-PFXCertificate function to send the PFX to the user through mail.
+To activate this function, you need to set the automation account variable "EnablePFXExport" to true and configure a mailbox in "PFXExportPasswordMailbox" to define, where the export password will be sent to.
+
+When the certificate is issued, the user will receive the exported PFX certificate and the ExportPasswordMailbox will receive the corresponding password. Do NOT send this password through the mail channel but utilize a password manager or another communication channel to do so!
+
 ## Appendix
 
 ### Troublshooting – Delete Certificate from Intune to request new certificate from Digicert

--- a/SetupScripts/Setup.ps1
+++ b/SetupScripts/Setup.ps1
@@ -2,6 +2,7 @@ Install-Module -Name PowerShellGet -Repository PSGallery -Force
 Install-Module -Name Microsoft.Graph.DeviceManagement.Administration -Scope AllUsers
 Install-Module -Name Microsoft.Graph.Groups -Scope AllUsers
 Install-Module -Name Microsoft.Graph.Users -Scope AllUsers
+Install-Module -Name Microsoft.Graph.Users.Actions -Scope AllUsers
 Install-Module -Name PSCertificateEnrollment -Scope AllUsers
 Install-Module -Name WPNinjas.PasswordGeneration -Scope AllUsers
 Install-Module -Name ExchangeOnlineManagement -Scope AllUsers

--- a/SetupScripts/SetupExo.ps1
+++ b/SetupScripts/SetupExo.ps1
@@ -1,10 +1,17 @@
 
 
-# Run Account of Azure Automation Account only specify value when Shared Mailbox Support should be enabled in the script.
+# Run Account of Azure Automation Account only specify value when Shared Mailbox Support and PFX Export should be enabled in the script.
 $RunAsObjectId = ""
 
+# Managed Identity Object of VM
+$VmMsiObjectId = ""
+# Mailbox that will send mails with the exported PFX
+$SendPFXMailbox
+
 Install-Module -Name AzureAD -Scope AllUsers
+Install-Module -Name ExchangeOnlineManagemenet -Scope AllUsers
 Connect-AzureAD
+Connect-ExchangeOnline
 
 if($null -ne $RunAsObjectId){
     $exo = Get-AzureADServicePrincipal -Filter "AppID eq '00000002-0000-0ff1-ce00-000000000000'"
@@ -31,4 +38,36 @@ if($null -ne $RunAsObjectId){
         $role = Get-AzureADDirectoryRole | Where-Object {$_.displayName -eq $roleName}
     }
     Add-AzureADDirectoryRoleMember -ObjectId $role.ObjectId -RefObjectId $RunAsObjectId
+
+    # Grant Mail.Send permission to VM identity
+
+    $vmmsi = Get-AzureADServicePrincipal -ObjectId $VmMsiObjectId 
+
+    $groupReadPermission = $graph.AppRoles `
+        | Where-Object Value -Like "Mail.Send" `
+        | Select-Object -First 1
+
+    New-AzureADServiceAppRoleAssignment `
+        -Id $groupReadPermission.Id `
+        -ObjectId $vmmsi.ObjectId `
+        -PrincipalId $vmmsi.ObjectId `
+        -ResourceId $exo.ObjectId
+
+    # Create mail-enabled security group to restrict send.mail permissions
+    New-DistributionGroup `
+        -Name "SMIME Send Mail Restriction" `
+        -Description "Restrict Send.Mail permission to specified group members" `
+        -Type security
+    
+    # Add member to distribution group, mails can only be sent through the defined member mailboxes
+    Add-DistributionGroupMember `
+        -Identity "SMIME Send Mail Restriction" `
+        -Member $SendPFXMailbox
+    
+    # Create ApplicationAccessPolicy to effectively restrict access
+    New-ApplicationAccessPolicy `
+        -AppId $vmmsi.ObjectId `
+        -PolicyScopeGroupId "SMIME Send Mail Restriction" `
+        -AccessRight RestrictAccess
+    
 }


### PR DESCRIPTION
Added a function "Send-PFXCertificate" which will export the SMIME certificate, send the PFX to the enduser and the export password to a mailbox that can be configured through an Automation Account Variable.
Added the necessary steps to configure the Send.Mail permission on the VM identity as well as configuring an EXO ApplicationAccessPolicy to Restrict the permission.

Also added a smaller change to make sure that nested group memberships are working on the defined AADScopeGroup

There was also an edge case with one user's mail addresses, where an empty string was transmitted. Added an additional filter to remove empty strings to make sure that the function New-DigicertSmimeOrder works as expected.

